### PR TITLE
Landing Page's scroll feature fixed

### DIFF
--- a/src/components/pages/dapps/Dapps.tsx
+++ b/src/components/pages/dapps/Dapps.tsx
@@ -14,9 +14,9 @@ interface Props {
 	slidesPerView: number
 }
 
-export default function Contributors (props: Props): JSX.Element {
+export default function Dapps(props: Props): JSX.Element {
 	return (
-		<div className="py-20 my-20 items-center" id="contributors">
+		<div className="py-20 my-20 items-center" id="djed_apps">
 			<h4 className='dappsSubtitle my-3'>Stablecoins based on the</h4>
 			<h2 className='dappsTitle mb-20'>Djed Protocol</h2>
 			<Swiper
@@ -25,8 +25,8 @@ export default function Contributors (props: Props): JSX.Element {
 				autoplay={{
 					delay: 2000,
 					disableOnInteraction: true,
-				}} 
-				slidesPerView={3} 
+				}}
+				slidesPerView={3}
 				navigation={false}
 				modules={[Navigation, Autoplay]}>
 				<SwiperSlide>
@@ -45,8 +45,8 @@ export default function Contributors (props: Props): JSX.Element {
 				autoplay={{
 					delay: 2000,
 					disableOnInteraction: true,
-				}} 
-				slidesPerView={props.slidesPerView-2} 
+				}}
+				slidesPerView={props.slidesPerView - 2}
 				navigation={false}
 				modules={[Navigation, Autoplay]}>
 				<SwiperSlide>


### PR DESCRIPTION
"Get started" button wasn't scrolling. The button targets the ID djed_apps, but the Dapps component was incorrectly using the ID contributors.
Fixes #16 


https://github.com/user-attachments/assets/88cdd4b3-e273-4e2f-8858-eb909b298462



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component naming and structural identifiers for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->