### PR TITLE
fix: resolve footer alignment issues (#31)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -401,3 +401,102 @@
     animation: logo-spin infinite 20s linear;
   }
 }
+
+/* Footer Styles */
+.footer-container {
+  width: 100%;
+  padding: 1.5rem 0;
+  margin-top: 4rem;
+  background: rgba(21, 21, 21, 0.5);
+  border-top: 1px solid rgba(243, 193, 129, 0.1);
+}
+
+.footer-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 100%;
+  padding: 0 2rem;
+  gap: 2rem;
+}
+
+.footer-copyright {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+  color: #F9EBDB;
+  margin: 0;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-brand img {
+  width: 32px;
+  height: auto;
+}
+
+.footer-title {
+  font-family: 'Space Mono', monospace;
+  font-size: 18px;
+  font-weight: 700;
+  color: #F9EBDB;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.footer-social {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-social a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0.5rem;
+  background: rgba(243, 193, 129, 0.1);
+  border: 1px solid rgba(243, 193, 129, 0.2);
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.footer-social a:hover {
+  background: rgba(243, 193, 129, 0.2);
+  border-color: rgba(243, 193, 129, 0.4);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(243, 193, 129, 0.3);
+}
+
+.footer-social img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+
+/* Footer Mobile Responsive */
+@media screen and (max-width: 768px) {
+  .footer-content {
+    flex-direction: column;
+    text-align: center;
+    padding: 0 1rem;
+  }
+
+  .footer-copyright {
+    order: 3;
+    margin-top: 1rem;
+  }
+
+  .footer-brand {
+    order: 1;
+  }
+
+  .footer-social {
+    order: 2;
+  }
+}

--- a/src/components/pages/footer/Footer.tsx
+++ b/src/components/pages/footer/Footer.tsx
@@ -5,17 +5,23 @@ import Twitter from '../../../assets/Twitter.png';
 
 const Footer = () => {
 	return (
-		<footer className='my-5'>
-			<div className='flex lg:flex-row flex-col lg:justify-evenly align-middle sm:justify-center md:justify-center'>
-				<p className='footerText lg:text-md sm:text-sm lg:mt-6 mb-3'>© Djed Alliance. All rights reserved.</p>
-				<div className='flex flex-row justify-center align-middle lg:my-0 my-3'>
-					<img src={Logo} className="mx-2 mb-1" alt="Djed Alliance logo" />
-					<p className='footerText lg:text-xl sm:text-sm mt-3 whitespace-pre'>Djed Alliance</p>
+		<footer className='footer-container'>
+			<div className='footer-content'>
+				<p className='footer-copyright'>© Djed Alliance. All rights reserved.</p>
+				<div className='footer-brand'>
+					<img src={Logo} alt="Djed Alliance logo" />
+					<p className='footer-title'>Djed Alliance</p>
 				</div>
-				<div className='flex flex-row mt-3 justify-center'>
-					<a href="https://discord.com/invite/5TWZwGXXym" target="_blank" rel="noreferrer" aria-label="Join Djed Alliance on Discord"><img className="socialImage mx-2 cursor-pointer" src={Discord} alt="Discord" /></a>
-					<a href="https://github.com/DjedAlliance" target="_blank" rel="noreferrer" aria-label="Djed Alliance GitHub"><img className="socialImage mx-2 cursor-pointer" src={GitHub} alt="GitHub" /></a>
-					<a href="https://twitter.com/DjedAlliance" target="_blank" rel="noreferrer" aria-label="Follow Djed Alliance on X (Twitter)"><img className="socialImage mx-2 cursor-pointer" src={Twitter} alt="X (Twitter)" /></a>
+				<div className='footer-social'>
+					<a href="https://discord.com/invite/5TWZwGXXym" target="_blank" rel="noreferrer" aria-label="Join Djed Alliance on Discord">
+						<img src={Discord} alt="Discord" />
+					</a>
+					<a href="https://github.com/DjedAlliance" target="_blank" rel="noreferrer" aria-label="Djed Alliance GitHub">
+						<img src={GitHub} alt="GitHub" />
+					</a>
+					<a href="https://twitter.com/DjedAlliance" target="_blank" rel="noreferrer" aria-label="Follow Djed Alliance on X (Twitter)">
+						<img src={Twitter} alt="X (Twitter)" />
+					</a>
 				</div>
 			</div>
 		</footer>


### PR DESCRIPTION
- Remove side gaps and ensure full-width coverage
- Fix uneven spacing between footer sections
- Align text and icons properly
- Reduce footer height for better proportions
- Add consistent padding and gap spacing
- Implement responsive layout for mobile devices
- Style social icons with glass effect matching navbar
- Ensure consistent layout across different screen sizes

Fixes #31 

###  Screenshots:
[
<img width="1897" height="1027" alt="Djed image pr" src="https://github.com/user-attachments/assets/f2de12c0-070d-4f03-9c83-81425e79ee36" />
](url)


## Checklist
<!-- Mark items with [x] to indicate completion -->

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [ ] If applicable, I have made corresponding changes or additions to the documentation.
- [ ] If applicable, I have made corresponding changes or additions to tests.
- [x] My changes generate no new warnings or errors.
- [x] I have joined the Stability Nexus's Discord server and I will share a link to this PR with the project maintainers there.
- [x] I have read the Contribution Guidelines.
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added complete footer styling with copyright, brand, and social media sections.
  * Implemented interactive hover effects for social icons with visual feedback.
  * Added responsive design that reorganizes footer layout for mobile devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DjedAlliance/DjedAlliance.github.io/pull/34?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->